### PR TITLE
Create table if not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ In more advanced cases, you may want to add [custom fields](#extra-fields) so th
 For your reference, here's the minimum schema of the table that Oxen uses:
 
 ```sql
-CREATE TABLE `oxen_queue` (
+CREATE TABLE IF NOT EXISTS `oxen_queue` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `batch_id` bigint(20) unsigned DEFAULT NULL,
   `job_type` varchar(200) NOT NULL,


### PR DESCRIPTION
taken from storage.js

Also from the docs,
/* If this is your first time running oxen, run this line to automatically create the database table. You should only need to run this once. */
await ox.createTable()

This should be safe to run with CREATE TABLE IF NOT EXISTS even later, so maybe remove this line ?


