### PR TITLE
Increase size of body column to varchar(10000)

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -8,7 +8,7 @@ const create_table =
       `job_type` varchar(200) NOT NULL, \
       `created_ts` datetime DEFAULT CURRENT_TIMESTAMP, \
       `started_ts` datetime DEFAULT NULL, \
-      `body` varchar(1000) DEFAULT NULL, \
+      `body` varchar(10000) DEFAULT NULL, \
       `status` varchar(100) NOT NULL DEFAULT 'waiting', \
       `result` varchar(1000) DEFAULT NULL, \
       `recovered` tinyint(1) NOT NULL DEFAULT '0', \


### PR DESCRIPTION
We recently ran into an issue with emails being placed in the queue that were longer than 1000 chars. Is there any reason not to increase the size of the body column to varchar(10000)? PR included ;-)