### PR TITLE
Change CHARSET encoding for storage table

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -22,7 +22,7 @@ const create_table =
       KEY `locking_update` (`job_type`,`batch_id`,`status`,`priority`), \
       KEY `next_jobs_select` (`batch_id`,`priority`), \
       KEY `started_ts` (`started_ts`,`job_type`,`status`) \
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8; \
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci; \
 "
 
 const delete_table = ' DROP TABLE IF EXISTS [[TABLE_NAME]] '


### PR DESCRIPTION
Encoded emojis will cause job inserts to fail using the current encoding type for the storage table.

https://stackoverflow.com/questions/39463134/how-to-store-emoji-character-in-mysql-database

To convert an existing table...

-- change default charset and collate on Oxen queue table
ALTER TABLE oxen_queue CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;