### PR TITLE
feat: allow for job retries

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -220,6 +220,12 @@ const queue = class {
                 `timeout for job_id ${job.id} (over ${_this.job_timeout_seconds} seconds)`
             )
             .then(async job_result => {
+                if (job_result._oxen_queue_retry_seconds) {
+                    return _this.handleRetry({
+                        job_id: job.id,
+                        retry_seconds: job_result._oxen_queue_retry_seconds,
+                    })
+                }
                 return _this.handleSuccess({ job_id: job.id, job_result, job_body: job.body })
             })
             .catch(async error => {
@@ -302,6 +308,22 @@ const queue = class {
                     id: job_id,
                 },
             ]
+        )
+    }
+
+    async handleRetry({ job_id, retry_seconds }) {
+        return this.dbQry(
+            `
+            update ${this.db_table} 
+            set 
+               status = "waiting", 
+               batch_id = NULL, 
+               started_ts = NULL,
+               created_ts = DATE_ADD(created_ts, INTERVAL ? SECOND),
+               recovered = recovered + 1
+            where ? 
+            LIMIT 1`,
+            [retry_seconds, { id: job_id }]
         )
     }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -220,7 +220,7 @@ const queue = class {
                 `timeout for job_id ${job.id} (over ${_this.job_timeout_seconds} seconds)`
             )
             .then(async job_result => {
-                if (job_result._oxen_queue_retry_seconds) {
+                if (job_result && job_result._oxen_queue_retry_seconds) {
                     return _this.handleRetry({
                         job_id: job.id,
                         retry_seconds: job_result._oxen_queue_retry_seconds,

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -10,7 +10,7 @@ const create_table =
       `started_ts` datetime DEFAULT NULL, \
       `body` varchar(10000) DEFAULT NULL, \
       `status` varchar(100) NOT NULL DEFAULT 'waiting', \
-      `result` varchar(1000) DEFAULT NULL, \
+      `result` mediumtext DEFAULT NULL, \
       `recovered` tinyint(1) NOT NULL DEFAULT '0', \
       `running_time` smallint(5) unsigned DEFAULT NULL, \
       `unique_key` int(11) unsigned DEFAULT NULL, \

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -22,7 +22,7 @@ const create_table =
       KEY `locking_update` (`job_type`,`batch_id`,`status`,`priority`), \
       KEY `next_jobs_select` (`batch_id`,`priority`), \
       KEY `started_ts` (`started_ts`,`job_type`,`status`) \
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci; \
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci; \
 "
 
 const delete_table = ' DROP TABLE IF EXISTS [[TABLE_NAME]] '

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "bluebird": "^3.7.2",
-    "lodash": "^4.17.20",
-    "mysql2": "^3.6.3"
+    "lodash": "^4.17.21",
+    "mysql2": "^3.12.0"
   },
   "scripts": {
     "test": "mocha test/ --timeout 6000 --exit"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxen-queue",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A resilient worker queue backed by MySQL.",
   "engines": {
     "node": ">=7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
+aws-ssl-profiles@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz#157dd77e9f19b1d123678e93f120e6f193022641"
+  integrity sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -155,7 +160,7 @@ is-property@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
   integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
-lodash@^4.17.20:
+lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -170,10 +175,10 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
   integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
 
-lru-cache@^8.0.0:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-8.0.5.tgz#983fe337f3e176667f8e567cfcce7cb064ea214e"
-  integrity sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==
+lru.min@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/lru.min/-/lru.min-1.1.1.tgz#146e01e3a183fa7ba51049175de04667d5701f0e"
+  integrity sha512-FbAj6lXil6t8z4z3j0E5mfRlPzxkySotzUHwRXjlpRh10vc6AI6WN62ehZj82VG7M20rqogJ0GLwar2Xa05a8Q==
 
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
@@ -216,16 +221,17 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-mysql2@^3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-3.6.3.tgz#d478be7aa97ea675d92f079d072f5a45cb772902"
-  integrity sha512-qYd/1CDuW1KYZjD4tzg2O8YS3X/UWuGH8ZMHyMeggMTXL3yOdMisbwZ5SNkHzDGlZXKYLAvV8tMrEH+NUMz3fw==
+mysql2@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-3.12.0.tgz#db8fc770f8b76ebaba49dc4bbfe2a1754057d882"
+  integrity sha512-C8fWhVysZoH63tJbX8d10IAoYCyXy4fdRFz2Ihrt9jtPILYynFEKUUzpp1U7qxzDc3tMbotvaBH+sl6bFnGZiw==
   dependencies:
+    aws-ssl-profiles "^1.1.1"
     denque "^2.1.0"
     generate-function "^2.3.1"
     iconv-lite "^0.6.3"
     long "^5.2.1"
-    lru-cache "^8.0.0"
+    lru.min "^1.0.0"
     named-placeholders "^1.1.3"
     seq-queue "^0.0.5"
     sqlstring "^2.3.2"


### PR DESCRIPTION
Allow for retrying jobs by returning 
```
{
    _oxen_queue_retry_seconds: SOME_SECONDS,
}
```
from `work_fn`